### PR TITLE
Remove Requires=duetcontrolserver.service again

### DIFF
--- a/pkg/duetwebserver/usr/lib/systemd/system/duetwebserver.service
+++ b/pkg/duetwebserver/usr/lib/systemd/system/duetwebserver.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Duet Web Server
 Wants=duetcontrolserver.service
-Requires=duetcontrolserver.service
 After=network.target duetcontrolserver.service
 
 [Service]


### PR DESCRIPTION
As it turns out adding the
```
Requires=duetcontrolserver.service
```
as proposed by me in #29 has diminishing returns.

It *does* work but it also forces a restart of `DWS` whenever `DCS` is restarted in contrast to just letting `DWS` run and trying to reconnect to `DCS`. This leads to unnecessarily elongated down-times when restarting `DCS` (20 seconds vs. 5 seconds).