### PR TITLE
Fixed processing of G29 commands

### DIFF
--- a/src/DuetControlServer/Codes/MCodes.cs
+++ b/src/DuetControlServer/Codes/MCodes.cs
@@ -315,6 +315,7 @@ namespace DuetControlServer.Codes
                             {
                                 await SPI.Interface.SetHeightmap(map);
                                 await SPI.Interface.UnlockAll(code.Channel);
+                                return new CodeResult(DuetAPI.MessageType.Success, $"Height map loaded from file {file}");
                             }
                         }
                         catch (AggregateException ae)


### PR DESCRIPTION
Gcodes::Process() was refactored to handle G29 S3 as well as G29 S1
without sending the command to the Duet.

GCodes::CodeExecuted() processing for G29 was updated to use
FilePath.DefaultHeightmapFile as the default height map instead
of the hard coded "heightmap.csv". (minor nit)

MCodes::Process() handling of M375 was fixed to return
MessageType.Success when loading was successful instead of falling
through and throwing an OperationCanceledException().