### PR TITLE
Packaging Tweaks

### DIFF
--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-PKG_DIR=$(readlink -f $(dirname @0))
+PKG_DIR=$(readlink -f $(dirname $0))
 COMMON_DIR=$PKG_DIR/common
 PACKAGE_TYPES="deb"
 HELP=0

--- a/pkg/common/common.functions
+++ b/pkg/common/common.functions
@@ -78,7 +78,7 @@ sdver=$(cat $PKG_DIR/deb/duetsd/DEBIAN/control | grep Version | cut -d ' ' -f 2)
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 
 case $TARGET_ARCH in
-	armhf|armhfp|arm|armv6h|armv7h) DOTNET_ARCH=linux-arm ;;
+	armhf|armhfp|arm|armv6h|armv7h|armv7hl) DOTNET_ARCH=linux-arm ;;
 	arm64|aarch64) DOTNET_ARCH=linux-arm64 ;;
 	x86_64) DOTNET_ARCH=linux-x64 ;;
 	i386|i686|x86_32)  DOTNET_ARCH=linux-x86 ;;
@@ -163,6 +163,10 @@ build_sd() {
 	echo "Building virtual SD card package v$sdver..."
 	rm -rf $DEST_DIR/duetsd_$sdver
 	mkdir -p $DEST_DIR/duetsd_$sdver
+	mkdir -p $DEST_DIR/duetsd_$sdver/opt/dsf/sd/filaments
+	mkdir -p $DEST_DIR/duetsd_$sdver/opt/dsf/sd/gcodes
+	mkdir -p $DEST_DIR/duetsd_$sdver/opt/dsf/sd/macros
+	mkdir -p $DEST_DIR/duetsd_$sdver/opt/dsf/sd/sys
 	[ -d $COMMON_DIR/duetsd/ ] && $RSYNC $COMMON_DIR/duetsd/. $DEST_DIR/duetsd_$sdver/ || :
 	[ -d $PACKAGER_DIR/duetsd/ ] && $RSYNC $PACKAGER_DIR/duetsd/. $DEST_DIR/duetsd_$sdver/ || :
 }

--- a/pkg/deb/build.sh
+++ b/pkg/deb/build.sh
@@ -39,11 +39,6 @@ pkg_progs() {
 pkg_sd() {
 	echo "- Packaging virtual SD card package v$sdver..."
 
-	mkdir -p $DEST_DIR/duetsd_$sdver/opt/dsf/sd/filaments
-	mkdir -p $DEST_DIR/duetsd_$sdver/opt/dsf/sd/gcodes
-	mkdir -p $DEST_DIR/duetsd_$sdver/opt/dsf/sd/macros
-	mkdir -p $DEST_DIR/duetsd_$sdver/opt/dsf/sd/sys
-
 	sed -i "s/TARGET_ARCH/$TARGET_ARCH/g" $DEST_DIR/duetsd_$sdver/DEBIAN/control
 	sed -i "s/SDVER/$sdver/g" $DEST_DIR/duetsd_$sdver/DEBIAN/control
 	dpkg-deb --build $DEST_DIR/duetsd_$sdver $DEST_DIR

--- a/pkg/rpm/build.sh
+++ b/pkg/rpm/build.sh
@@ -16,19 +16,19 @@ mkdir -p $DEST_DIR
 pkg_progs() {
 	echo "- Packaging programs..."
 	rpmbuild --target=${TARGET_ARCH}-linux-gnu --define="%_topdir $RPMBUILD_DIR" --define="%_arch $TARGET_ARCH" \
-		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $dcsver" -bb ${PACKAGER_DIR}/duetcontrolserver.spec
+		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $dcsver" -ba ${PACKAGER_DIR}/duetcontrolserver.spec
 	rpmbuild --target=${TARGET_ARCH}-linux-gnu --define="%_topdir $RPMBUILD_DIR" --define="%_arch $TARGET_ARCH" \
-		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $dwsver" -bb ${PACKAGER_DIR}/duetwebserver.spec
+		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $dwsver" -ba ${PACKAGER_DIR}/duetwebserver.spec
 	rpmbuild --target=${TARGET_ARCH}-linux-gnu --define="%_topdir $RPMBUILD_DIR" --define="%_arch $TARGET_ARCH" \
-		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $dcsver" -bb ${PACKAGER_DIR}/duettools.spec
+		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $dcsver" -ba ${PACKAGER_DIR}/duettools.spec
 	rpmbuild --target=${TARGET_ARCH}-linux-gnu --define="%_topdir $RPMBUILD_DIR" --define="%_arch $TARGET_ARCH" \
-		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $dcsver" -bb ${PACKAGER_DIR}/duetruntime.spec
+		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $dcsver" -ba ${PACKAGER_DIR}/duetruntime.spec
 }
 
 pkg_sd() {
 	echo "- Packaging virtual SD card package v$sdver..."
 	rpmbuild --target=noarch --define="%_topdir $RPMBUILD_DIR" --define="%_arch noarch" \
-		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $sdver" -bb ${PACKAGER_DIR}/duetsd.spec
+		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $sdver" -ba ${PACKAGER_DIR}/duetsd.spec
 }
 
 pkg_dwc() {
@@ -37,13 +37,13 @@ pkg_dwc() {
 
 	rpmbuild --target=noarch --define="%_topdir $RPMBUILD_DIR" --define="%_arch noarch" \
 		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion ${dwcver%%-*}"  --define="%_release ${dwcver##*-}" \
-		-bb ${PACKAGER_DIR}/duetwebcontrol.spec
+		-ba ${PACKAGER_DIR}/duetwebcontrol.spec
 }
 
 pkg_meta() {
 	echo "- Packaging meta..."
 	rpmbuild --target=${TARGET_ARCH}-linux-gnu --define="%_topdir $RPMBUILD_DIR" --define="%_arch $TARGET_ARCH" \
-		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $dcsver" -bb ${PACKAGER_DIR}/duetsoftwareframework.spec
+		--define="%_build_type ${BUILD_TYPE}" --define="%_tversion $dcsver" -ba ${PACKAGER_DIR}/duetsoftwareframework.spec
 }
 
 [ $BUILD_PROGS -eq 1 ] && { [ $BUILD -eq 1 ] && build_progs || : ; } && [ $PKGS -eq 1 ] && pkg_progs

--- a/pkg/rpm/duetcontrolserver.spec
+++ b/pkg/rpm/duetcontrolserver.spec
@@ -11,7 +11,7 @@
 
 Name:    duetcontrolserver
 Version: %{_tversion}
-Release: 900
+Release: 901
 Summary: DSF Control Server
 Group:   3D Printing
 Source0: duetcontrolserver_%{_tversion}
@@ -19,6 +19,7 @@ License: GPLv3
 URL:     https://github.com/chrishamm/DuetSoftwareFramework
 BuildRequires: rpm >= 4.7.2-2
 Requires: duetruntime
+%systemd_requires
 
 AutoReq:  0
 
@@ -33,18 +34,26 @@ DSF Control Server
 %install
 rsync -vaH %{S:0}/. %{buildroot}/
 
+%pre
+if [ $1 -gt 1 ] && systemctl -q is-active %{name}.service ; then
+# upgrade
+	systemctl stop %{name}.service > /dev/null 2>&1 || :
+fi
+
 %post
-/bin/systemctl daemon-reload >/dev/null 2>&1 || :
-/bin/systemctl enable duetcontrolserver.service >/dev/null 2>&1 || :
+systemctl daemon-reload >/dev/null 2>&1 || :
 
 %preun
-if [ "$1" -eq "0" ]; then
-	/bin/systemctl --no-reload disable duetcontrolserver.service > /dev/null 2>&1 || :
-	/bin/systemctl stop duetcontrolserver.service > /dev/null 2>&1 || :
+if [ $1 -eq 0 ] ; then
+# remove
+	systemctl --no-reload disable %{name}.service >/dev/null 2>&1 || :
 fi
 
 %postun
-/bin/systemctl daemon-reload >/dev/null 2>&1 || :
+if [ $1 -eq 1 ] && systemctl -q is-enabled %{name}.service ; then
+# upgrade
+	systemctl start %{name}.service
+fi
 
 %files
 %defattr(-,root,root,-)

--- a/pkg/rpm/duetruntime.spec
+++ b/pkg/rpm/duetruntime.spec
@@ -10,7 +10,7 @@
 
 Name:    duetruntime
 Version: %{_tversion}
-Release: 900
+Release: 901
 Summary: DSF Common Runtime Components
 Group:   3D Printing
 Source0: duetruntime_%{_tversion}
@@ -32,32 +32,6 @@ DSF Common Runtime Components
 rsync -vaH %{S:0}/. %{buildroot}/
 
 %files
-%defattr(-,root,root,-)
-%{dsfoptdir}/bin/Zhaobang.IO.SeekableStreamReader.dll
-%{dsfoptdir}/bin/System.*
-%{dsfoptdir}/bin/Nito.*
-%{dsfoptdir}/bin/Newtonsoft.*
-%{dsfoptdir}/bin/netstandard.dll
-%{dsfoptdir}/bin/Microsoft.*
-%{dsfoptdir}/bin/LinuxDevices.*
-%{dsfoptdir}/bin/libclrjit.so
-%{dsfoptdir}/bin/libcoreclr.so
-%{dsfoptdir}/bin/libhostfxr.so
-%{dsfoptdir}/bin/libhostpolicy.so
-%{dsfoptdir}/bin/DuetAPI.*
-%{dsfoptdir}/bin/DuetAPIClient.*
-
-%{dsfoptdir}/bin/WindowsBase.dll
-%{dsfoptdir}/bin/SOS.NETCore.dll
-%{dsfoptdir}/bin/sosdocsunix.txt
-%{dsfoptdir}/bin/mscorlib.dll
-%{dsfoptdir}/bin/libsos.so
-%{dsfoptdir}/bin/libmscordbi.so
-%{dsfoptdir}/bin/libmscordaccore.so
-%{dsfoptdir}/bin/libdbgshim.so
-%{dsfoptdir}/bin/libcoreclrtraceptprovider.so
-%{dsfoptdir}/bin/Remotion.Linq.dll
-
-%if %{?_build_type} == "Debug"
-%{dsfoptdir}/bin/libsosplugin.so
-%endif
+%defattr(0644,root,root,-)
+%{dsfoptdir}/bin/*
+%attr(0755,root,root) %{dsfoptdir}/bin/createdump

--- a/pkg/rpm/duetsd.spec
+++ b/pkg/rpm/duetsd.spec
@@ -10,7 +10,7 @@
 
 Name:    duetsd
 Version: %{_tversion}
-Release: 900
+Release: 901
 Summary: DSF SD Card
 Group:   3D Printing
 Source0: duetsd_%{_tversion}
@@ -32,5 +32,10 @@ DSF SD Card
 rsync -vaH %{S:0}/. %{buildroot}/
 
 %files
-%defattr(-,root,root,-)
-%{dsfoptdir}/sd/sys/iapduet3.bin
+%defattr(0664,root,root,0775)
+%dir %{dsfoptdir}/sd/sys
+%config(noreplace) %{dsfoptdir}/sd/sys/config.g
+%{dsfoptdir}/sd/sys/*.bin
+%dir %{dsfoptdir}/sd/filaments
+%dir %{dsfoptdir}/sd/gcodes
+%dir %{dsfoptdir}/sd/macros

--- a/pkg/rpm/duetsoftwareframework.spec
+++ b/pkg/rpm/duetsoftwareframework.spec
@@ -10,12 +10,12 @@
 
 Name:    duetsoftwareframework
 Version: %{_tversion}
-Release: 900
+Release: 901
 Summary: Duet Software Framework
 Group:   3D Printing
 License: GPLv3
 URL:     https://github.com/chrishamm/DuetSoftwareFramework
-Source0: duetsoftwareframework-%{version}-%{release}
+Source0: duetsoftwareframework_%{_tversion}
 
 BuildRequires: rpm >= 4.7.2-2
 

--- a/pkg/rpm/duettools.spec
+++ b/pkg/rpm/duettools.spec
@@ -10,7 +10,7 @@
 
 Name:    duettools
 Version: %{_tversion}
-Release: 900
+Release: 901
 Summary: DSF Tools
 Group:   3D Printing
 Source0: duettools_%{_tversion}
@@ -33,6 +33,10 @@ DSF Tools
 rsync -vaH %{S:0}/. %{buildroot}/
 
 %files
-%defattr(-,root,root,-)
-%{dsfoptdir}/bin/CodeLogger*
-%{dsfoptdir}/bin/CodeConsole*
+%defattr(0664,root,root,-)
+%attr(0755, root, root) %{dsfoptdir}/bin/CodeLogger
+%{dsfoptdir}/bin/CodeLogger.*
+%attr(0755, root, root) %{dsfoptdir}/bin/CodeConsole
+%{dsfoptdir}/bin/CodeConsole.*
+%attr(0755, root, root) %{dsfoptdir}/bin/ModelObserver
+%{dsfoptdir}/bin/ModelObserver.*


### PR DESCRIPTION
* Added armv7hl to list of valid architectures
* Moved creation of SD card directories to common.functions
* The rpm build now also creates srpms.
* Fix systemctl commands in spec files to not try and replace files
  with duetcontrolserver or duetwebserver running.
* Update spec files for .NET Core 3.0.
* Update spec files for inclusion of the IAP binaries.
* Update spec files for new ModelObserver utility.
* Fix typo in pkg/build.sh that was looking for parse_args in
  the wrong place when not run from the pkg directory.