### PR TITLE
Unload services before installing/upgrading

### DIFF
--- a/pkg/deb/duetcontrolserver/DEBIAN/preinst
+++ b/pkg/deb/duetcontrolserver/DEBIAN/preinst
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# If running, stop duetcontrolserver before updating it
+if (systemctl -q is-active duetcontrolserver); then
+    systemctl -q stop duetcontrolserver
+fi

--- a/pkg/deb/duetwebserver/DEBIAN/preinst
+++ b/pkg/deb/duetwebserver/DEBIAN/preinst
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# If running, stop duetwebserver before updating it
+if (systemctl -q is-active duetwebserver); then
+    systemctl -q stop duetwebserver
+fi

--- a/pkg/rpm/duetcontrolserver.spec
+++ b/pkg/rpm/duetcontrolserver.spec
@@ -33,6 +33,11 @@ DSF Control Server
 %install
 rsync -vaH %{S:0}/. %{buildroot}/
 
+%pre
+if (systemctl -q is-active duetcontrolserver.service); then
+    systemctl -q stop duetcontrolserver.service >/dev/null 2>&1 || :
+fi
+
 %post
 /bin/systemctl daemon-reload >/dev/null 2>&1 || :
 /bin/systemctl enable duetcontrolserver.service >/dev/null 2>&1 || :

--- a/pkg/rpm/duetwebserver.spec
+++ b/pkg/rpm/duetwebserver.spec
@@ -33,6 +33,11 @@ DSF Web Server
 %install
 rsync -vaH %{S:0}/. %{buildroot}/
 
+%pre
+if (systemctl -q is-active duetwebserver.service); then
+    systemctl -q stop duetwebserver.service >/dev/null 2>&1 || :
+fi
+
 %post
 /bin/systemctl daemon-reload >/dev/null 2>&1 || :
 /bin/systemctl enable duetwebserver.service >/dev/null 2>&1 || :


### PR DESCRIPTION
I think this should be fairly safe and will prevent an edge case where the package cannot correctly update the file on disk due to the process running at the moment of the upgrade. 

The biggest edge cases I can think of are if there is an ongoing print, it would probably lead to tears. If there is a way to check for an active print, that might be a wise thing to add to the `preinst` and bail on the install if so.