### PR TITLE
DWC 2 is now in master, remove --branch next from clone

### DIFF
--- a/pkg/common/common.functions
+++ b/pkg/common/common.functions
@@ -176,7 +176,7 @@ build_dwc() {
 			cp -r ~/duet/DuetWebControl $DEST_DIR/DuetWebControl
 		else
 			echo "- Cloning repository..."
-			git clone -q --single-branch --branch next https://github.com/chrishamm/DuetWebControl.git $DEST_DIR/DuetWebControl
+			git clone -q --single-branch https://github.com/chrishamm/DuetWebControl.git $DEST_DIR/DuetWebControl
 		fi
 	else
 		echo "- Using existing repository in $DEST_DIR/DuetWebControl"


### PR DESCRIPTION
Since the `next` branch was merged into master, lets remove this from the git clone command (otherwise it errors out as the branch is gone).