### PR TITLE
Exit when done with M999

### DIFF
--- a/src/DuetControlServer/Codes/MCodes.cs
+++ b/src/DuetControlServer/Codes/MCodes.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace DuetControlServer.Codes
 {
@@ -841,7 +842,8 @@ namespace DuetControlServer.Codes
                     if (code.Parameters.Count == 0)
                     {
                         await SPI.Interface.RequestReset();
-                        return new CodeResult();
+                        Environment.Exit(0);
+                        return new CodeResult();  // This should never execute, due to the exit. 
                     }
                     break;
             }


### PR DESCRIPTION
Exit DuetControlServer entirely when it finishes processing an M999 (restart).  It will be restarted within a few seconds by systemctl